### PR TITLE
check if resolution is interlaced

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vcraescu/go-xrandr
+module github.com/askm3/go-xrandr
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/xrandr.go
+++ b/xrandr.go
@@ -15,8 +15,9 @@ type RefreshRateValue float32
 
 // Size screen size or resolution
 type Size struct {
-	Width  float32
-	Height float32
+	Width      float32
+	Height     float32
+	Interlaced bool
 }
 
 // Position screen position
@@ -341,8 +342,8 @@ func parseSize(s string) (*Size, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not parse mode width size (%s): %s", s, err)
 	}
-
-	height, err := strconv.Atoi(strings.TrimSpace(res[1]))
+	heightStr, interlaced := isInterlaced(strings.TrimSpace(res[1]))
+	height, err := strconv.Atoi(heightStr)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse mode height size (%s): %s", s, err)
 	}
@@ -350,7 +351,18 @@ func parseSize(s string) (*Size, error) {
 	return &Size{
 		Width:  float32(width),
 		Height: float32(height),
+		Interlaced: interlaced,
 	}, nil
+}
+
+func isInterlaced(height string) (string, bool) {
+	re := regexp.MustCompile("(i|p)$")
+	if !re.MatchString(height) {
+		return height, false
+	}
+	lastChar := len(height) - 1
+	interlaced := height[lastChar] == 'i'
+	return height[:lastChar], interlaced
 }
 
 func parseSizeWithPosition(s string) (*Size, *Position, error) {

--- a/xrandr_test.go
+++ b/xrandr_test.go
@@ -403,14 +403,14 @@ func TestMonitor_DPI(t *testing.T) {
 					{Current: false, Value: xrandr.RefreshRateValue(54)},
 				},
 				Resolution: xrandr.Size{
-					Width: 3840,
+					Width:  3840,
 					Height: 2160,
 				},
 			},
 		},
 
 		Size: xrandr.Size{
-			Width: 487,
+			Width:  487,
 			Height: 247,
 		},
 	}


### PR DESCRIPTION
if xrandr outputs a resolution like **1920x1080i**
the xrandr.GetScreens() panics on method parseSize.

I added a Interlaced (bool) on Size struct.